### PR TITLE
ci: quote 0x addresses in env to avoid YAML int parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Build frontend
         env:
-          NEXT_PUBLIC_TOKEN: 0xBcbfe2410353DFEdc057582FBc0Fa2915580436E
-          NEXT_PUBLIC_POOL:  0x0aF0d8e964CbFb0ACf10F82567DEc20405cc214a
+          NEXT_PUBLIC_TOKEN: "0xBcbfe2410353DFEdc057582FBc0Fa2915580436E"
+          NEXT_PUBLIC_POOL:  "0x0aF0d8e964CbFb0ACf10F82567DEc20405cc214a"
         run: |
           echo "Building frontend..."
           pnpm --filter app build


### PR DESCRIPTION
Summary

Fix GitHub Actions YAML parsing where unquoted 0x… values were treated as integers, causing the workflow to fail.

Changes

Quote NEXT_PUBLIC_TOKEN and NEXT_PUBLIC_POOL values in .github/workflows/ci.yml.

Sweep to quote any other unquoted 0x… literals in the workflow.

Why

YAML interprets bare 0x… as int. Quoting ensures the runner receives strings and the job can build the app with dummy envs.

Test Plan

Merge this PR.

Check Actions → CI: workflow should start and pass the Build frontend step.

Risk / Rollback

Low (workflow-only). Roll back by reverting this commit.