### PR TITLE
fix: normalize amounts and convert to uint64 micro; relayer encryptU6…

### DIFF
--- a/app/lib/amount.ts
+++ b/app/lib/amount.ts
@@ -1,0 +1,19 @@
+import { ethers } from "ethers";
+
+// Max for uint64
+export const U64_MAX = 18446744073709551615n;
+
+// Normalize a human string like "0,001" or "0.001" to uint64 micro-units (6 decimals)
+export function toU64Micro(input: string): bigint {
+  if (!input) throw new Error("Enter an amount");
+  const s = input.replace(",", ".").trim();
+  const v = ethers.parseUnits(s, 6);
+  if (v < 0n) throw new Error("Amount must be positive");
+  if (v > U64_MAX) throw new Error("Amount too large for uint64");
+  return v;
+}
+
+// Format a u64 micro value for display (e.g., dashboard)
+export function fromU64Micro(v: bigint, frac: number = 6): string {
+  return ethers.formatUnits(v, frac);
+}


### PR DESCRIPTION
Summary

Normalize user-entered amounts and convert them safely to uint64 micro-units (6 decimals), fixing “Amount too large for uint64” and comma/locale input issues.

Changes

Add app/lib/amount.ts:

toU64Micro("0,001" | "0.001") -> bigint (6-decimals, validated)

fromU64Micro(bigint) -> string

Update relayer helper to encryptU64(contract, user, value: bigint).

Refactor Actions.tsx to:

parse input with toU64Micro

pass bigint to relayer

improve error messages

use friendly placeholders (e.g., 0.001)

Why

The UI previously passed JS numbers and mixed locales (, vs .), which led to overflow / mis-scaling when encrypting amounts.

Test Plan

Restart dev server.

Run: Faucet 0.002 → Deposit 0.002 → Borrow 0.001 → Repay 0.0005.

All txs should succeed; no uint64 overflow errors.

Risk / Rollback

Low (frontend-only). Revert if needed.