### PR TITLE
fix(app): use token.decimals() everywhere; parse to uint64 in token units; remove 2-decimal restriction

### DIFF
--- a/app/components/Dashboard.tsx
+++ b/app/components/Dashboard.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { ethers } from "ethers";
 import { getPool, TOKEN_ADDR, POOL_ADDR } from "@/lib/contracts";
+import { getTokenDecimals } from "@/lib/tokenMeta";
 import { getSigner, getUserAddress, isMetaMaskConnected, getProvider } from "../lib/ethers";
 
 // Contract ABIs (simplified for demo - using standard uint256 for now)
@@ -27,6 +28,7 @@ interface Position {
   balance: bigint;
   healthFactor: boolean;
   ltv: number;
+  decimals: number;
 }
 
 export default function Dashboard({ tokenAddress, poolAddress }: DashboardProps) {
@@ -88,6 +90,7 @@ export default function Dashboard({ tokenAddress, poolAddress }: DashboardProps)
       const poolContract = await getPool()
       const tokenContract = new ethers.Contract(tokenAddress, TOKEN_ABI, signer);
       const userAddress = await getUserAddress();
+      const decimals = await getTokenDecimals();
       
       // Test contract connectivity first
       console.log("🔍 Testing contract connectivity...");
@@ -121,7 +124,8 @@ export default function Dashboard({ tokenAddress, poolAddress }: DashboardProps)
         debt,
         balance,
         healthFactor,
-        ltv
+        ltv,
+        decimals
       });
       
     } catch (error: any) {
@@ -228,7 +232,7 @@ export default function Dashboard({ tokenAddress, poolAddress }: DashboardProps)
           <div className="bg-blue-50 p-4 rounded-lg">
             <h3 className="text-lg font-semibold text-blue-900 mb-2">💰 Token Balance</h3>
             <div className="text-2xl font-bold text-blue-700">
-              {ethers.formatEther(position.balance)} cUSD
+              {ethers.formatUnits(position.balance, position.decimals)} cUSD
             </div>
           </div>
 
@@ -237,7 +241,7 @@ export default function Dashboard({ tokenAddress, poolAddress }: DashboardProps)
             <div className="bg-green-50 p-4 rounded-lg">
               <h3 className="text-lg font-semibold text-green-900 mb-2">📈 Total Deposits</h3>
               <div className="text-2xl font-bold text-green-700">
-                {formatWithDecimals(position.deposit, 6)} cUSD
+                {formatWithDecimals(position.deposit, position.decimals)} cUSD
               </div>
               <div className="text-xs text-green-600 mt-1">
                 🔒 Encrypted on-chain
@@ -247,7 +251,7 @@ export default function Dashboard({ tokenAddress, poolAddress }: DashboardProps)
             <div className="bg-red-50 p-4 rounded-lg">
               <h3 className="text-lg font-semibold text-red-900 mb-2">💳 Total Debt</h3>
               <div className="text-2xl font-bold text-red-700">
-                {formatWithDecimals(position.debt, 6)} cUSD
+                {formatWithDecimals(position.debt, position.decimals)} cUSD
               </div>
               <div className="text-xs text-red-600 mt-1">
                 🔒 Encrypted on-chain

--- a/app/lib/amount.ts
+++ b/app/lib/amount.ts
@@ -1,19 +1,17 @@
 import { ethers } from "ethers";
-
-// Max for uint64
 export const U64_MAX = BigInt("18446744073709551615");
 
-// Normalize a human string like "0,001" or "0.001" to uint64 micro-units (6 decimals)
-export function toU64Micro(input: string): bigint {
+// Normalize "0,02" or "0.02" into uint64 *token units* (decimals read from chain)
+export function toU64Units(input: string, decimals: number): bigint {
   if (!input) throw new Error("Enter an amount");
   const s = input.replace(",", ".").trim();
-  const v = ethers.parseUnits(s, 6);
+  // NOTE: parseUnits throws on invalid
+  const v = ethers.parseUnits(s, decimals); // bigint in smallest token units
   if (v < BigInt(0)) throw new Error("Amount must be positive");
   if (v > U64_MAX) throw new Error("Amount too large for uint64");
   return v;
 }
 
-// Format a u64 micro value for display (e.g., dashboard)
-export function fromU64Micro(v: bigint, frac: number = 6): string {
-  return ethers.formatUnits(v, frac);
+export function fromUnits(v: bigint, decimals: number): string {
+  return ethers.formatUnits(v, decimals);
 }

--- a/app/lib/tokenMeta.ts
+++ b/app/lib/tokenMeta.ts
@@ -1,0 +1,15 @@
+import { getToken } from "@/lib/contracts";
+
+let _decimals: number | null = null;
+
+export async function getTokenDecimals(): Promise<number> {
+  if (_decimals !== null) return _decimals;
+  const t = await getToken();
+  try {
+    const d = Number(await t.decimals?.());
+    _decimals = Number.isFinite(d) ? d : 18;
+  } catch {
+    _decimals = 18; // fallback
+  }
+  return _decimals!;
+}


### PR DESCRIPTION
Summary

Use the token’s on-chain decimals() everywhere for parsing and display. Amounts are now converted to uint64 in token units and balances render with the correct decimals. Removed the old “2-decimal” input restriction.

Changes

New helpers: app/lib/amount.ts (toU64Units, fromUnits) and app/lib/tokenMeta.ts (getTokenDecimals() with caching).

Actions.tsx: parse inputs with dynamic decimals; send bigint units to relayer; no 2-decimals validation.

Dashboard.tsx: format values using decimals instead of hardcoded 18/6.

Why

Fixes inconsistent scaling (e.g., faucet showing 0.00000000000004 cUSD) and rejects/overflows due to mis-parsed amounts.

Test Plan

Start dev server; connect to Sepolia.

Faucet 0.02 → balance displays ~0.02 cUSD.

Deposit 0.02 → Borrow 0.01 → Repay 0.005 (all succeed).

No “2-decimal” validation message appears.

Risk

Low (frontend only). Revert if needed.