### PR TITLE
feat(app): detect faucet max by static call; show max and clamp amounts above limit

### DIFF
--- a/app/lib/faucetLimit.ts
+++ b/app/lib/faucetLimit.ts
@@ -1,0 +1,44 @@
+import { ethers } from "ethers";
+import { getToken } from "@/lib/contracts";
+import { getTokenDecimals } from "@/lib/tokenMeta";
+
+/**
+ * Probes the faucet limit by trying candidate amounts with a static call.
+ * Returns { maxHuman, maxUnits, decimals } where:
+ *  - maxHuman: string in human units (e.g. "0.005")
+ *  - maxUnits: bigint in smallest units
+ */
+export async function getFaucetMax() {
+  const token = await getToken();
+  const decimals = await getTokenDecimals();
+
+  // Candidates to try (human strings). Adjust as needed.
+  const candidates = ["0.001","0.002","0.003","0.005","0.01","0.02","0.05"];
+
+  let lastOk: { human: string, units: bigint } | null = null;
+
+  for (const h of candidates) {
+    const human = h.replace(",",".").trim();
+    const units = ethers.parseUnits(human, decimals);
+    try {
+      // v6: simulate gas usage to see if it would revert
+      await token.faucet.staticCall(units);
+      lastOk = { human, units };
+    } catch {
+      // first revert means we've hit/over the limit; stop
+      break;
+    }
+  }
+
+  if (!lastOk) {
+    // extremely small fallback (should always pass)
+    const tiny = "0.0001";
+    return {
+      maxHuman: tiny,
+      maxUnits: ethers.parseUnits(tiny, decimals),
+      decimals,
+    };
+  }
+
+  return { maxHuman: lastOk.human, maxUnits: lastOk.units, decimals };
+}


### PR DESCRIPTION
Summary

Prevent faucet reverts by discovering the contract’s per-call max via a staticCall, showing it in the UI, and blocking inputs above the limit. Accepts both 0,02 and 0.02.

Changes

Add app/lib/faucetLimit.ts:

getFaucetMax() probes candidate amounts with token.faucet.staticCall(...) and returns the highest non-reverting value (in human and unit form).

Actions.tsx:

Fetch faucet max on mount; display (max X) next to Faucet label.

Clamp/validate entered amount against the max (friendly toast instead of on-chain revert).

Works with locale commas or dots; amounts still parsed via token decimals().

Why

Users hit execution reverted: Amount too large despite valid formatting. Probing the limit off-chain gives a smooth UX and avoids wasted gas/time.

Test Plan

Reload app; Faucet label shows (max …).

Enter an amount > max → UI error, no tx sent.

Enter an amount ≤ max → Faucet success; balance increases accordingly.

Deposit → Borrow (≤70% LTV) → Repay.

Risk

Low (frontend only). Revert if needed.