### PR TITLE
fix(app): fetch token decimals on first use (init as null, not 18)

### DIFF
--- a/app/components/Actions.tsx
+++ b/app/components/Actions.tsx
@@ -151,7 +151,7 @@ export default function Actions({ tokenAddress, poolAddress }: ActionsProps) {
     }
   };
 
-  let _decimals = 18;
+  let _decimals: number | null = null;
   const [faucetMax, setFaucetMax] = useState<string>("");
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
Summary

Ensure the app uses the actual token decimals from chain by initializing the local decimals cache to null and fetching on first use, instead of defaulting to 18.

Changes

Actions.tsx: set _decimals: number | null = null; and load via getTokenDecimals() before parsing amounts.

No functional changes elsewhere; this just guarantees correct scaling on first interaction.

Why

Defaulting to 18 could parse amounts with the wrong scale on the first call, causing “Invalid amount” or unexpected values until a later refresh.

Test Plan

Start app, connect to Sepolia.

Faucet 0.001 (or the displayed faucet max) → succeeds on first try.

Amounts display with correct decimals without needing a reload.

Risk

Minimal (frontend-only, one line). Revert if needed.