### PR TITLE
ci: add optional fhEVM test job (runs when FHEVM_RPC_URL is set)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,43 @@ jobs:
         cd contracts
         pnpm hardhat test
         
+  test-contracts-fhevm:
+    name: Test Contracts (fhEVM)
+    runs-on: ubuntu-latest
+    needs: compile-contracts
+    if: ${{ secrets.FHEVM_RPC_URL != '' }}
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        
+    - name: Enable pnpm (corepack)
+      run: corepack enable
+      
+    - name: Cache pnpm store (if lockfile present)
+      if: ${{ hashFiles('pnpm-lock.yaml') != '' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.pnpm-store
+        key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-${{ runner.os }}-
+          
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile || pnpm install
+      
+    - name: Run fhEVM contract tests
+      env:
+        FHEVM_RPC_URL: ${{ secrets.FHEVM_RPC_URL }}
+      run: |
+        cd contracts
+        pnpm hardhat test --network fhevm
+        
   test-frontend:
     name: Test Frontend
     runs-on: ubuntu-latest

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -30,6 +30,11 @@ export default {
     hardhat: {
       chainId: 31337,
     },
+    fhevm: {
+      url: process.env.FHEVM_RPC_URL || "",
+      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+      chainId: 0x1a1, // 417 in hex, common fhEVM testnet chainId
+    },
   },
   mocha: {
     timeout: 120000, // 120 seconds


### PR DESCRIPTION
Adds a conditional job to run encrypted tests on a real fhEVM RPC via GitHub secret FHEVM_RPC_URL. Vanilla jobs remain unchanged.